### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning][semver].
 
+## [0.4.0] - 2020-08-28
+
+### Added
+
+- `misc` module with `add_reactions` and `add_reactions_blocking` functions.
+- `non_blocking` field for `MenuOptions`.
+- [dependency] Add tokio.
+- Add tests.
+
+### Changed
+
+- Make `reaction_prompt` add reactions in a separate, non-blocking task.
+- Convert `examples` into a workspace.
+- Allow `Menu` to have reactions added in a non-blocking fashion.
+
 ## [0.3.0] - 2020-08-25
 
 ### Changed
@@ -31,3 +46,4 @@ This project adheres to [Semantic Versioning][semver].
 <!-- TAGS -->
 [0.2.0]: https://github.com/AriusX7/serenity-utils/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/AriusX7/serenity-utils/compare/v0.2.0...v0.3.0
+[0.4.0]: https://github.com/AriusX7/serenity-utils/compare/v0.3.0...v0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,8 @@ rustls_backend = ["serenity/rustls_backend"]
 version = "0.9.0-rc.0"
 default-features = false
 features = ["client", "collector", "gateway", "model"]
+
+[dependencies.tokio]
+version = "0.2.22"
+default-features = false
+features = ["rt-core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serenity_utils"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["AriusX7 <icyligii@gmail.com>"]
 edition = "2018"
 license = "ISC"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To use this crate, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-serenity_utils = "0.3.0"
+serenity_utils = "0.4.0"
 ```
 
 **Note:** This crate only supports [serenity]'s async versions and a minimum of Rust 1.39.
@@ -144,7 +144,7 @@ You can specify features by adding this to your `Cargo.toml`:
 
 ```toml
 [dependencies.serenity_utils]
-version = "0.3.0"
+version = "0.4.0"
 
 # To disable default features.
 default-features = false

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = [
+    "e01_prompts",
+    "e02_menu",
+    "e03_conversion",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod conversion;
 mod error;
 pub mod formatting;
 pub mod menu;
+pub mod misc;
 pub mod prelude;
 pub mod prompt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! To use this crate, add the following to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! serenity_utils = "0.3.0"
+//! serenity_utils = "0.4.0"
 //! ```
 //!
 //! **Note:** This crate only supports [`serenity`]'s async versions.

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -16,7 +16,7 @@
 //! [`Red-DiscordBot`]: https://github.com/Cog-Creators/Red-DiscordBot/
 //! [`menu`]: https://github.com/Cog-Creators/Red-DiscordBot/blob/46eb9ce7a0bcded991af02665fec39fcb542c76d/redbot/core/utils/menus.py#L17
 
-use crate::{Error, misc::add_reactions};
+use crate::{misc::add_reactions, Error};
 use serenity::{
     builder::CreateMessage,
     collector::ReactionAction,
@@ -217,7 +217,12 @@ impl<'a> Menu<'a> {
 
     async fn add_reactions(&self, msg: &Message) -> MenuResult {
         if self.options.non_blocking {
-            let emojis = self.options.controls.iter().map(|c| c.emoji.clone()).collect::<Vec<_>>();
+            let emojis = self
+                .options
+                .controls
+                .iter()
+                .map(|c| c.emoji.clone())
+                .collect::<Vec<_>>();
 
             add_reactions(self.ctx, msg, emojis).await?;
         } else {

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,0 +1,49 @@
+//! Miscellaneous utility functions to aid with performing common tasks.
+
+use crate::Error;
+use serenity::{
+    model::prelude::{Message, ReactionType},
+    prelude::Context,
+};
+
+/// Adds reactions in a non-blocking fashion.
+///
+/// This allows you to perform other tasks while reactions are being added. This
+/// works by creating a separate task for adding emojis in the background. The
+/// order of `emojis` is preserved.
+///
+/// See [`add_reactions_blocking`] to add reactions in a blocking fashion. This
+/// function is slightly less efficient than the blocking counterpart.
+///
+/// [`add_reactions_blocking`]: fn.add_reactions_blocking.html
+pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionType>) -> Result<(), Error> {
+    let channel_id = msg.channel_id;
+    let msg_id = msg.id;
+    let http = self.ctx.http.clone();
+
+    tokio::spawn(async move {
+        for emoji in emojis {
+            http.create_reaction(channel_id.0, msg_id.0, &emoji).await?;
+        }
+
+        Result::<_, SerenityError>::Ok(())
+    });
+
+    Ok(())
+}
+
+/// Adds reactions in a blocking fashion.
+///
+/// This blocks the execution of code until all reactions are added. The order
+/// of `emojis` is preserved.
+///
+/// See [`add_reactions`] to add reactions in a non-blocking fashion.
+///
+/// [`add_reactions`]: fn.add_reactions.html
+pub async fn add_reactions_blocking(ctx: &Context, msg: &Message, emojis: &[ReactionType]) -> Result<(), Error> {
+    for emoji in emojis {
+        ctx.http.create_reaction(msg.channel_id.0, msg.id.0, emoji).await?;
+    }
+
+    Ok(())
+}

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -4,6 +4,7 @@ use crate::Error;
 use serenity::{
     model::prelude::{Message, ReactionType},
     prelude::Context,
+    Error as SerenityError,
 };
 
 /// Adds reactions in a non-blocking fashion.
@@ -19,7 +20,7 @@ use serenity::{
 pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionType>) -> Result<(), Error> {
     let channel_id = msg.channel_id;
     let msg_id = msg.id;
-    let http = self.ctx.http.clone();
+    let http = ctx.http.clone();
 
     tokio::spawn(async move {
         for emoji in emojis {

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -3,7 +3,7 @@
 use serenity::{
     model::prelude::{Message, ReactionType},
     prelude::Context,
-    Error as SerenityError,
+    Error,
 };
 
 /// Adds reactions in a non-blocking fashion.
@@ -16,7 +16,7 @@ use serenity::{
 /// function is slightly less efficient than the blocking counterpart.
 ///
 /// [`add_reactions_blocking`]: fn.add_reactions_blocking.html
-pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionType>) -> Result<(), SerenityError> {
+pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionType>) -> Result<(), Error> {
     let channel_id = msg.channel_id;
     let msg_id = msg.id;
     let http = ctx.http.clone();
@@ -26,7 +26,7 @@ pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionTyp
             http.create_reaction(channel_id.0, msg_id.0, &emoji).await?;
         }
 
-        Result::<_, SerenityError>::Ok(())
+        Result::<_, Error>::Ok(())
     });
 
     Ok(())
@@ -40,7 +40,7 @@ pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionTyp
 /// See [`add_reactions`] to add reactions in a non-blocking fashion.
 ///
 /// [`add_reactions`]: fn.add_reactions.html
-pub async fn add_reactions_blocking(ctx: &Context, msg: &Message, emojis: &[ReactionType]) -> Result<(), SerenityError> {
+pub async fn add_reactions_blocking(ctx: &Context, msg: &Message, emojis: &[ReactionType]) -> Result<(), Error> {
     for emoji in emojis {
         ctx.http.create_reaction(msg.channel_id.0, msg.id.0, emoji).await?;
     }

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -16,7 +16,11 @@ use serenity::{
 /// function is slightly less efficient than the blocking counterpart.
 ///
 /// [`add_reactions_blocking`]: fn.add_reactions_blocking.html
-pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionType>) -> Result<(), Error> {
+pub async fn add_reactions(
+    ctx: &Context,
+    msg: &Message,
+    emojis: Vec<ReactionType>,
+) -> Result<(), Error> {
     let channel_id = msg.channel_id;
     let msg_id = msg.id;
     let http = ctx.http.clone();
@@ -40,9 +44,15 @@ pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionTyp
 /// See [`add_reactions`] to add reactions in a non-blocking fashion.
 ///
 /// [`add_reactions`]: fn.add_reactions.html
-pub async fn add_reactions_blocking(ctx: &Context, msg: &Message, emojis: &[ReactionType]) -> Result<(), Error> {
+pub async fn add_reactions_blocking(
+    ctx: &Context,
+    msg: &Message,
+    emojis: &[ReactionType],
+) -> Result<(), Error> {
     for emoji in emojis {
-        ctx.http.create_reaction(msg.channel_id.0, msg.id.0, emoji).await?;
+        ctx.http
+            .create_reaction(msg.channel_id.0, msg.id.0, emoji)
+            .await?;
     }
 
     Ok(())

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -1,6 +1,5 @@
 //! Miscellaneous utility functions to aid with performing common tasks.
 
-use crate::Error;
 use serenity::{
     model::prelude::{Message, ReactionType},
     prelude::Context,
@@ -17,7 +16,7 @@ use serenity::{
 /// function is slightly less efficient than the blocking counterpart.
 ///
 /// [`add_reactions_blocking`]: fn.add_reactions_blocking.html
-pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionType>) -> Result<(), Error> {
+pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionType>) -> Result<(), SerenityError> {
     let channel_id = msg.channel_id;
     let msg_id = msg.id;
     let http = ctx.http.clone();
@@ -41,7 +40,7 @@ pub async fn add_reactions(ctx: &Context, msg: &Message, emojis: Vec<ReactionTyp
 /// See [`add_reactions`] to add reactions in a non-blocking fashion.
 ///
 /// [`add_reactions`]: fn.add_reactions.html
-pub async fn add_reactions_blocking(ctx: &Context, msg: &Message, emojis: &[ReactionType]) -> Result<(), Error> {
+pub async fn add_reactions_blocking(ctx: &Context, msg: &Message, emojis: &[ReactionType]) -> Result<(), SerenityError> {
     for emoji in emojis {
         ctx.http.create_reaction(msg.channel_id.0, msg.id.0, emoji).await?;
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,4 +14,5 @@ pub use super::builder::prelude::{EmbedBuilder, MessageBuilder};
 pub use super::conversion::Conversion;
 pub use super::formatting::{pagify, PagifyOptions};
 pub use super::menu::{Menu, MenuOptions};
+pub use super::misc::*;
 pub use super::prompt::*;

--- a/src/prompt/reaction.rs
+++ b/src/prompt/reaction.rs
@@ -26,7 +26,6 @@ use serenity::{
     futures::StreamExt,
     model::prelude::{Message, ReactionType, User},
     prelude::Context,
-    Error as SerenityError,
 };
 use std::time::Duration;
 

--- a/src/prompt/reaction.rs
+++ b/src/prompt/reaction.rs
@@ -20,12 +20,13 @@
 //! }
 //! ```
 
-use crate::error::Error;
+use crate::{error::Error, misc::add_reactions};
 use serenity::{
     collector::ReactionAction,
     futures::StreamExt,
     model::prelude::{Message, ReactionType, User},
     prelude::Context,
+    Error as SerenityError,
 };
 use std::time::Duration;
 
@@ -89,11 +90,7 @@ pub async fn reaction_prompt(
     emojis: &[ReactionType],
     timeout: f32,
 ) -> Result<(usize, ReactionType), Error> {
-    for emoji in emojis {
-        ctx.http
-            .create_reaction(msg.channel_id.0, msg.id.0, &emoji)
-            .await?;
-    }
+    add_reactions(ctx, msg, emojis.to_vec()).await?;
 
     let mut collector = user
         .await_reactions(&ctx)

--- a/tests/test_builder.rs
+++ b/tests/test_builder.rs
@@ -1,0 +1,128 @@
+use serenity::{builder::*, model::prelude::ReactionType};
+use serenity_utils::builder::prelude::*;
+
+#[test]
+fn test_to_create_embed_author() {
+    let mut builder = EmbedAuthorBuilder::new("Arius");
+    builder.set_url("https://github.com/AriusX7/serenity-utils");
+
+    let mut create_embed_author = CreateEmbedAuthor::default();
+    create_embed_author
+        .name("Arius")
+        .url("https://github.com/AriusX7/serenity-utils");
+
+    assert_eq!(builder.to_create_embed_author().0, create_embed_author.0);
+}
+
+#[test]
+fn test_to_create_embed_footer() {
+    let mut builder = EmbedFooterBuilder::new("text");
+    builder.set_icon_url("https://github.com/AriusX7/serenity-utils");
+
+    let mut create_embed_footer = CreateEmbedFooter::default();
+    create_embed_footer
+        .text("text")
+        .icon_url("https://github.com/AriusX7/serenity-utils");
+
+    assert_eq!(builder.to_create_embed_footer().0, create_embed_footer.0);
+}
+
+#[test]
+fn test_to_create_embed() {
+    let mut builder = EmbedBuilder::new();
+    builder
+        .set_description("This is the embed description.")
+        .set_author_with(|a| {
+            a.set_name("The embed author name!")
+        });
+
+    let mut create_embed = CreateEmbed::default();
+    create_embed
+        .description("This is the embed description.")
+        .author(|a| {
+            a.name("The embed author name!")
+        });
+
+    assert_eq!(builder.to_create_embed().0, create_embed.0);
+}
+
+#[test]
+fn test_to_create_message() {
+    let mut builder = MessageBuilder::new();
+    builder
+        .set_content("This is the message content.")
+        .set_embed_with(|e| {
+            e.set_description("This is the embed description.");
+            e.set_author_with(|a| {
+                a.set_name("The embed author name!");
+
+                a
+            });
+
+            e
+        })
+        .add_reactions(vec![
+            ReactionType::from('🐶'),
+            ReactionType::from('🐱'),
+        ]);
+
+    let transformed_create_message = builder.to_create_message();
+
+    let mut create_message = CreateMessage::default();
+    create_message
+        .content("This is the message content.")
+        .embed(|e| {
+            e.description("This is the embed description.");
+            e.author(|a| {
+                a.name("The embed author name!");
+
+                a
+            });
+
+            e
+        })
+        .reactions(vec![
+            ReactionType::from('🐶'),
+            ReactionType::from('🐱'),
+        ]);
+
+    assert_eq!(transformed_create_message.0, create_message.0);
+    assert_eq!(transformed_create_message.1, create_message.1);
+}
+
+#[test]
+fn test_to_edit_message() {
+    let mut builder = MessageBuilder::new();
+    builder
+        .set_content("This is the message content.")
+        .set_embed_with(|e| {
+            e.set_description("This is the embed description.");
+            e.set_author_with(|a| {
+                a.set_name("The embed author name!");
+
+                a
+            });
+
+            e
+        })
+        .add_reactions(vec![
+            ReactionType::from('🐶'),
+            ReactionType::from('🐱'),
+        ]);
+
+    let mut edit_message = EditMessage::default();
+    edit_message
+        .content("This is the message content.")
+        .embed(|e| {
+            e.description("This is the embed description.");
+            e.author(|a| {
+                a.name("The embed author name!");
+
+                a
+            });
+
+            e
+        });
+
+    assert_eq!(builder.to_edit_message().0, edit_message.0);
+}

--- a/tests/test_formatting.rs
+++ b/tests/test_formatting.rs
@@ -1,0 +1,37 @@
+use serenity_utils::formatting::{escape_mass_mentions, pagify, PagifyOptions};
+
+#[test]
+fn test_pagify() {
+    let mut options = PagifyOptions::default();
+    options.page_length(30).shorten_by(0).priority(true);
+
+    let pages = pagify(
+        "This is the first sentence.\
+        \nAnother sentence.\nThis is a long sentence and \
+        will be broken into two.",
+        options,
+    );
+
+    assert_eq!(
+        vec![
+            "This is the first sentence.",
+            "\nAnother sentence.",
+            "\nThis is a long sentence and",
+            " will be broken into two."
+        ],
+        pages
+    );
+}
+
+#[test]
+fn test_escape_mass_mentions() {
+    let text = "Hello, @everyone! I can filter both @everyone and @here pings!";
+
+    assert_eq!(
+        escape_mass_mentions(text),
+        String::from(
+            "Hello, @\u{200b}everyone! I can filter both @\u{200b}everyone \
+            and @\u{200b}here pings!"
+        )
+    )
+}


### PR DESCRIPTION
### Added

- `misc` module with `add_reactions` and `add_reactions_blocking` functions.
- `non_blocking` field for `MenuOptions`.
- [dependency] Add tokio.
- Add tests.

### Changed

- Make `reaction_prompt` add reactions in a separate, non-blocking task.
- Convert `examples` into a workspace.
- Allow `Menu` to have reactions added in a non-blocking fashion.
