### PR TITLE
Hide cache traits for implementors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serenity_utils"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["AriusX7 <icyligii@gmail.com>"]
 edition = "2018"
 license = "ISC"

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -120,6 +120,7 @@ impl Conversion for Role {
     type Item = Self;
 
     /// Converts `arg` into a `Role` object.
+    #[cfg(feature = "cache")]
     async fn from_guild_and_str(guild: &Guild, arg: &str) -> Option<Self>
     where
         Self: Sized,
@@ -164,6 +165,7 @@ impl Conversion for Member {
     type Item = Self;
 
     /// Converts `arg` into a `Member` object.
+    #[cfg(feature = "cache")]
     async fn from_guild_and_str(guild: &Guild, arg: &str) -> Option<Self>
     where
         Self: Sized,
@@ -206,6 +208,7 @@ impl Conversion for GuildChannel {
     type Item = Self;
 
     /// Converts `arg` into a `GuildChannel` object.
+    #[cfg(feature = "cache")]
     async fn from_guild_and_str(guild: &Guild, arg: &str) -> Option<Self>
     where
         Self: Sized,


### PR DESCRIPTION
`Conversion` traits have a hidden `from_guild_and_str` for non-cache feature builds, but the implementors unconditionally implement `Conversion`.

This patch hides these cache-only `Conversion` trait functions so cache may be be omitted without error.