### PR TITLE
Bump serenity and tokio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning][semver].
 
+## [0.5.2] - 2020-11-28
+
+### Changed
+
+- [dependency] Bump to serenity `0.10`. \[[@AriusX7]; [c:d12ab9f]]
+- [dependency] Bump to tokio `1.0`. \[[@AriusX7]; [c:d12ab9f]]
+- [dependency] Update examples to serenity `0.10` and tokio `1.0`. \[[@AriusX7]; [c:47f1e6a]]
+
 ## [0.5.1] - 2020-11-28
 
 ### Changed
@@ -65,12 +73,15 @@ This project adheres to [Semantic Versioning][semver].
 [0.4.0]: https://github.com/AriusX7/serenity-utils/compare/v0.3.0...v0.4.0
 [0.5.0]: https://github.com/AriusX7/serenity-utils/compare/v0.4.0...v0.5.0
 [0.5.1]: https://github.com/AriusX7/serenity-utils/compare/v0.5.0...v0.5.1
+[0.5.2]: https://github.com/AriusX7/serenity-utils/compare/v0.5.1...v0.5.2
 
 <!-- CONTRIBUTORS -->
 [@AriusX7]: https://github.com/AriusX7
 [@Headline]: https://github.com/Headline
 
 <!-- COMMITS -->
+[c:47f1e6a]: https://github.com/AriusX7/serenity-utils/commit/47f1e6acaaa90f4e279bdcdd16fbf136fc8a27ef
+[c:d12ab9f]: https://github.com/AriusX7/serenity-utils/commit/d12ab9fc95fa2ebce431c4682c78e2f8eb21a836
 [c:99f35a6]: https://github.com/AriusX7/serenity-utils/commit/99f35a6f502302b7242a13fa0e11bc5eb7adc460
 [c:41a3b91]: https://github.com/AriusX7/serenity-utils/commit/41a3b91536368719a1f7dcc4f217808414acf770
 [c:2d43851]: https://github.com/AriusX7/serenity-utils/commit/2d4385195826027a486e4b1752a2ceac17fb3b99

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,11 @@ native_tls_backend = ["serenity/native_tls_backend"]
 rustls_backend = ["serenity/rustls_backend"]
 
 [dependencies.serenity]
-version = "0.9.1"
+version = "0.10"
 default-features = false
 features = ["client", "collector", "gateway", "model"]
 
 [dependencies.tokio]
-version = "0.2.22"
+version = "1.0"
 default-features = false
-features = ["rt-core"]
+features = ["rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serenity_utils"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["AriusX7 <icyligii@gmail.com>"]
 edition = "2018"
 license = "ISC"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To use this crate, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-serenity_utils = "0.5.1"
+serenity_utils = "0.5.2"
 ```
 
 **Note:** This crate only supports [serenity]'s async versions and a minimum of Rust 1.39.
@@ -144,7 +144,7 @@ You can specify features by adding this to your `Cargo.toml`:
 
 ```toml
 [dependencies.serenity_utils]
-version = "0.5.1"
+version = "0.5.2"
 
 # To disable default features.
 default-features = false

--- a/examples/e01_prompts/Cargo.toml
+++ b/examples/e01_prompts/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 path = "../../"
 
 [dependencies.serenity]
-version = "0.9.0-rc.0"
+version = "0.10"
 
 [dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e01_prompts/src/main.rs
+++ b/examples/e01_prompts/src/main.rs
@@ -37,7 +37,7 @@ async fn main() {
         .group(&GENERAL_GROUP);
 
     let token = env::var("DISCORD_TOKEN").expect("token");
-    let mut client = Client::new(token)
+    let mut client = Client::builder(token)
         .event_handler(Handler)
         .framework(framework)
         .await

--- a/examples/e02_menu/Cargo.toml
+++ b/examples/e02_menu/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 path = "../../"
 
 [dependencies.serenity]
-version = "0.9.0-rc.0"
+version = "0.10"
 
 [dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e02_menu/src/main.rs
+++ b/examples/e02_menu/src/main.rs
@@ -123,7 +123,7 @@ async fn main() {
         .group(&GENERAL_GROUP);
 
     let token = env::var("DISCORD_TOKEN").expect("token");
-    let mut client = Client::new(token)
+    let mut client = Client::builder(token)
         .event_handler(Handler)
         .framework(framework)
         .await

--- a/examples/e03_conversion/Cargo.toml
+++ b/examples/e03_conversion/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2018"
 path = "../../"
 
 [dependencies.serenity]
-version = "0.9.0-rc.0"
+version = "0.10"
 default-features = false
 features = ["framework", "standard_framework"]
 
 [dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/e03_conversion/src/main.rs
+++ b/examples/e03_conversion/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
         .group(&GENERAL_GROUP);
 
     let token = env::var("DISCORD_TOKEN").expect("token");
-    let mut client = Client::new(token)
+    let mut client = Client::builder(token)
         .event_handler(Handler)
         .framework(framework)
         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! To use this crate, add the following to your `Cargo.toml`:
 //! ```toml
 //! [dependencies]
-//! serenity_utils = "0.5.1"
+//! serenity_utils = "0.5.2"
 //! ```
 //!
 //! **Note:** This crate only supports [`serenity`]'s async versions.


### PR DESCRIPTION
This pull request bumps `serenity` to `0.10`, `tokio` to `1.0` and `serenity_utils` itself to `0.5.2`.

### Changed

- [dependency] Bump to serenity `0.10`.
- [dependency] Bump to tokio `1.0`.
- [dependency] Update examples to serenity `0.10` and tokio `1.0`.

**Edit:** The `serenity_utils` version was incorrectly bumped to `0.5.2`. The correct version should've been `0.6.0`. It was fixed via commits directly on the `current` branch.
